### PR TITLE
Adding __all__ statements for py3 compatibility

### DIFF
--- a/batman/__init__.py
+++ b/batman/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['transitmodel', 'tests', 'plots']
 
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 from .transitmodel import *
 from .tests import *

--- a/batman/openmp.py
+++ b/batman/openmp.py
@@ -9,6 +9,9 @@ Check for OpenMP based on
 https://github.com/MDAnalysis/mdanalysis/tree/develop/package/setup.py
 retrieved 06/15/15
 """
+
+__all__ = ['detect']
+
 def detect():
 	"""Does this compiler support OpenMP parallelization?"""
 	compiler = new_compiler()

--- a/batman/plots.py
+++ b/batman/plots.py
@@ -24,6 +24,7 @@ from . import _nonlinear_ld
 import timeit
 import batman
 
+__all__ = ['make_plots']
 
 def wrapper(func, *args, **kwargs):
     def wrapped():

--- a/batman/tests.py
+++ b/batman/tests.py
@@ -20,7 +20,9 @@ import math
 import matplotlib.pyplot as plt
 import timeit
 from .transitmodel import *
-from .openmp import *
+from .openmp import detect
+
+__all__ = ['test']
 
 def wrapper(func, *args, **kwargs):
     def wrapped():
@@ -76,7 +78,7 @@ def test():
 			failures += 1
 
 	print("\nTesting multithreading...")
-	if openmp.detect():
+	if detect():
 		params.u = [0.1, 0.3]
 		params.limb_dark = "quadratic"
 		m = TransitModel(params, t, nthreads = 1)

--- a/batman/transitmodel.py
+++ b/batman/transitmodel.py
@@ -29,12 +29,14 @@ from math import pi
 import multiprocessing
 from . import openmp
 
+__all__ = ['TransitModel', 'TransitParams']
+
 def wrapper(func, *args, **kwargs):
     def wrapped():
         return func(*args, **kwargs)
     return wrapped
 
-class TransitModel:
+class TransitModel(object):
 	"""
 	Class for generating model transit light curves.	
 


### PR DESCRIPTION
Hey @lkreidberg! I'm using `batman` with Python 3, and I'm pretty sure these extra statements are needed for compatibility. After adding these, the tests pass with Python 2 and 3.

I also iterated the version to "0.9.1" - I'm not sure if that's the convention you like, let me know if you'd like it to appear differently.