### PR TITLE
Adding true anomaly method

### DIFF
--- a/batman/__init__.py
+++ b/batman/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['transitmodel', 'tests', 'plots']
 
 
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 
 from .transitmodel import *
 from .tests import *

--- a/batman/transitmodel.py
+++ b/batman/transitmodel.py
@@ -105,7 +105,7 @@ class TransitModel(object):
 		self.supersample_factor = supersample_factor
 		self.exp_time = exp_time
 		if self.supersample_factor > 1:  # IJMC: now do it quicker, with no loops:
-                        t_offsets = np.linspace(-self.exp_time/2., self.exp_time/2., self.supersample_factor)
+			t_offsets = np.linspace(-self.exp_time/2., self.exp_time/2., self.supersample_factor)
 			self.t_supersample = (t_offsets + self.t.reshape(self.t.size, 1)).flatten()
 		else: self.t_supersample = self.t
 		
@@ -272,7 +272,15 @@ class TransitModel(object):
 		phase = self._get_phase(params, "primary")
 		phase2 = self._get_phase(params, "secondary")
 		return params.t_secondary + params.per*(phase-phase2)
-			
+
+	def get_true_anomaly(self):
+		"""
+		Return the true anomaly at each time
+		"""
+		self.f = _rsky._getf(self.t_supersample, self.t0, self.per, self.a,
+							  self.inc*pi/180., self.ecc, self.w*pi/180.,
+							  self.transittype)
+		return self.f
 
 class TransitParams(object):
 	"""

--- a/c_src/_rsky.c
+++ b/c_src/_rsky.c
@@ -96,7 +96,7 @@ static PyObject *_getf(PyObject *self, PyObject *args)
 		(see the section by Murray, and Winn eq. 5).  In the Mandel & Agol
 		(2002) paper, this quantity is denoted d.
 	*/
-	double ecc, E, inc, a, d, f, omega, per, M, n, tp, tc, eps, t, BIGD = 100.;
+	double ecc, E, inc, a, f, omega, per, M, n, tp, tc, eps, t;
 	int transittype;
 	npy_intp i, dims[1];
 	PyArrayObject *ts, *fs;

--- a/c_src/_rsky.c
+++ b/c_src/_rsky.c
@@ -22,6 +22,8 @@
 
 static PyObject *_rsky(PyObject *self, PyObject *args);
 
+static PyObject *_getf(PyObject *self, PyObject *args);
+
 double getE(double M, double e)	//calculates the eccentric anomaly (see Seager Exoplanets book:  Murray & Correia eqn. 5 -- see section 3)
 {
 	double E = M, eps = 1.0e-7;
@@ -83,6 +85,59 @@ static PyObject *_rsky(PyObject *self, PyObject *args)
 	return PyArray_Return((PyArrayObject *)ds);
 } 
 
+
+
+static PyObject *_getf(PyObject *self, PyObject *args)
+{
+	/*
+		This module computes the distance between the centers of the
+		star and the planet in the plane of the sky.  This parameter is
+		denoted r_sky = sqrt(x^2 + y^2) in the Seager Exoplanets book
+		(see the section by Murray, and Winn eq. 5).  In the Mandel & Agol
+		(2002) paper, this quantity is denoted d.
+	*/
+	double ecc, E, inc, a, d, f, omega, per, M, n, tp, tc, eps, t, BIGD = 100.;
+	int transittype;
+	npy_intp i, dims[1];
+	PyArrayObject *ts, *fs;
+
+  	if(!PyArg_ParseTuple(args,"Oddddddi", &ts, &tc, &per, &a, &inc, &ecc, &omega, &transittype)) return NULL;
+
+	dims[0] = PyArray_DIMS(ts)[0];
+	fs = (PyArrayObject *) PyArray_SimpleNew(1, dims, PyArray_TYPE(ts));
+
+	double *t_array = PyArray_DATA(ts);
+	double *f_array = PyArray_DATA(fs);
+
+	n = 2.*M_PI/per;	// mean motion
+	eps = 1.0e-7;
+
+	for(i = 0; i < dims[0]; i++)
+	{
+		t = t_array[i];
+
+		//calculates time of periastron passage from time of inferior conjunction
+		f = M_PI/2. - omega;								//true anomaly corresponding to time of primary transit center
+		E = 2.*atan(sqrt((1. - ecc)/(1. + ecc))*tan(f/2.));				//corresponding eccentric anomaly
+		M = E - ecc*sin(E);
+		tp = tc - per*M/2./M_PI;							//time of periastron
+
+		if(ecc < 1.0e-5)
+		{
+			f = ((t - tp)/per - (int)((t - tp)/per))*2.*M_PI;			//calculates f for a circular orbit
+		}
+		else
+		{
+			M = n*(t - tp);
+			E = getE(M, ecc);
+			f = 2.*atan(sqrt((1.+ecc)/(1.-ecc))*tan(E/2.));
+		}
+		f_array[i] = f;
+	}
+	return PyArray_Return((PyArrayObject *)fs);
+}
+
+
 static char _rsky_doc[] = """ This module computes the distance between the centers of the \
 star and the planet in the plane of the sky.  This parameter is \
 denoted r_sky = sqrt(x^2 + y^2) in the Seager Exoplanets book \
@@ -90,8 +145,15 @@ denoted r_sky = sqrt(x^2 + y^2) in the Seager Exoplanets book \
 this quantity is denoted d.\
 LK 4/27/12 """;
 
+
+static char _getf_doc[] = """ This module computes the true anomaly. This parameter is \
+denoted f in the Seager Exoplanets book \
+(see the section by Murray, and Winn eq. 44).\
+BM 1/18/16 """;
+
+
 static PyMethodDef _rsky_methods[] = {
-  {"_rsky", _rsky,METH_VARARGS,_rsky_doc},{NULL}};
+  {"_rsky", _rsky,METH_VARARGS,_rsky_doc},{"_getf", _getf,METH_VARARGS,_getf_doc},{NULL}};
 
 
 #if PY_MAJOR_VERSION >= 3

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ _rsky = Extension('batman._rsky', ['c_src/_rsky.c'])
 _eclipse = Extension('batman._eclipse', ['c_src/_eclipse.c'])
 
 setup(	name='batman-package', 
-	version="2.1.1", 
+	version="2.2.0",
 	author='Laura Kreidberg',
 	author_email = 'laura.kreidberg@uchicago.edu',
 	url = 'https://github.com/lkreidberg/batman',


### PR DESCRIPTION
I'm doing some calculations that require me to compute true anomaly as a function of time. Rather than reinventing the wheel, I copied the portions of the `_rsky` function that compute `f` to a new function `_getf` within the `_rsky` module, and then created the necessary hooks to access `_getf` from the `TransitModel` object via the new method `TransitModel.get_true_anomaly`. 

If you think this could be useful to the people and consider merging this PR, you might also consider minimizing redundant code within `_rsky` by making `_rsky._rsky` call the new `_rsky._getf` method so that those guts aren't repeated, but I didn't want to touch a function as important to batman as `_rsky._rsky` without making sure you were in charge of the change.

In addition, when running the master branch with or without my changes, there's a `TabError` that occurs in Python 3 from line 108 of `transitmodel.py`, which I've corrected.

I've incremented the version number to `2.2.0` since this is a new feature.

***

For a sanity check that it works, here's a plot I made of the light curve from batman, and the star and planet (black circle, to scale) at three different times – mid-transit, and first and fourth contact. I computed the contact times by computing the true anomaly like this: 
```
    m = batman.TransitModel(transit_params, times)
    true_anomaly = m.get_true_anomaly()
```
and then converted `true_anomaly` to cartesian coordinates with Eqn. 2-4 of Winn's chapter in Seager's Exoplanets text.
![figure_1](https://cloud.githubusercontent.com/assets/3497584/12411807/628e0d58-be36-11e5-80b6-15c58d9d49e2.png)


The tests pass after the changes I've made in both Python 2 and Python 3:
```
  ____       ____
  )   \     /   (
   )_  \_V_/  _(
     )__   __(
        `-'
```