### PR TITLE
Don't require matplotlib

### DIFF
--- a/batman/plots.py
+++ b/batman/plots.py
@@ -17,7 +17,6 @@
 from __future__ import print_function
 import numpy as np
 import math
-import matplotlib.pyplot as plt
 from .transitmodel import *
 from . import _quadratic_ld
 from . import _nonlinear_ld
@@ -33,6 +32,7 @@ def wrapper(func, *args, **kwargs):
 
 
 def make_plots():
+	import matplotlib.pyplot as plt
 	"""zs = np.linspace(0., 1., 1000)
 	rp = 0.1
 	wrapped = wrapper(_quadratic_ld._quadratic_ld, zs, rp, 0.1, 0.3, 1)

--- a/batman/tests.py
+++ b/batman/tests.py
@@ -17,7 +17,6 @@
 from __future__ import print_function
 import numpy as np
 import math
-import matplotlib.pyplot as plt
 import timeit
 from .transitmodel import *
 from .openmp import detect

--- a/batman/transitmodel.py
+++ b/batman/transitmodel.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import matplotlib.pyplot as plt
 from . import _nonlinear_ld
 from . import _quadratic_ld
 from . import _uniform_ld
@@ -165,6 +164,7 @@ class TransitModel(object):
 	
 			err = np.max(np.abs(f-f0))*1.0e6
 			if plot == True:
+				import matplotlib.pyplot as plt
 				plt.plot(ds, 1.0e6*(f-f0), color='k')
 				plt.xlabel("d (separation of centers)")
 				plt.ylabel("Error (ppm)") 

--- a/setup.py
+++ b/setup.py
@@ -89,5 +89,8 @@ setup(	name='batman-package',
 		],
 	include_dirs = [np.get_include()],
 	install_requires = ['numpy'],
+	extras_requires= {
+	    'matplotlib': ['matplotlib'],
+	},
 	ext_modules=[_nonlinear_ld, _quadratic_ld, _uniform_ld, _logarithmic_ld, _exponential_ld, _custom_ld, _rsky, _eclipse]
 )


### PR DESCRIPTION
Matplotlib is only really required for the tests, and rendering the precision diagram. The core use of the package should not require the user to install `matplotlib`.

This change moves the `matplotlib` imports to only the sections of the code that perform actual plotting, and adds `matplotlib` as an optional dependency in `setup.py` so the user can install `batman` with:

```
pip install batman-package[matplotlib]
```