### PR TITLE
Supersampling pattern change

### DIFF
--- a/batman/transitmodel.py
+++ b/batman/transitmodel.py
@@ -109,9 +109,9 @@ class TransitModel(object):
 			params.rp = -1.*params.rp
 			self.inverse = True
 
-		if self.supersample_factor > 1:  # IJMC: now do it quicker, with no loops:
-			t_offsets = np.linspace(-self.exp_time/2., self.exp_time/2., self.supersample_factor)
-			self.t_supersample = (t_offsets + self.t.reshape(self.t.size, 1)).flatten()
+		if self.supersample_factor > 1:
+                        t_offsets = self.exp_time * ((np.arange(1, self.supersample_factor+1, dtype='d') - 0.5)/self.supersample_factor - 0.5)
+                        self.t_supersample = (self.t[:, np.newaxis] + t_offsets).ravel()                    
 		else: self.t_supersample = self.t
 		
 		if transittype == "primary": self.transittype = 1


### PR DESCRIPTION
Here's a small fix to Issue #18 that improves supersampling (slightly) when using a small supersampling factor. 

The sampling pattern used in Batman weights the exposure endpoints more than they should be weighted. This fix changes the sampling pattern to sample the exposures uniformly.

As an extreme example, the current pattern is computed for 2 supersamples (showing two exposures) as

    |-------|-------|  
    .       :       .     

where `-`marks an fraction of the exposure time, `|` mark the exposure start/endpoints (and also a fraction of the exposure time), and `.` and `:` mark the sample positions. The sample positions match the edges of the exposure, and are computed twice (once for each exposure). 

The sampling in this fix (with 2 supersamples and two exposures) looks like

    |-.---.-|-.---.-|

The sample distance inside an exposure is the same as the distance between the the nearest-to-edge samples between the previous/next exposure, and we don't do any redundant model evaluations. This samples the light curves uniformly in time, if we assume that the readout time is an insignificant fraction of the total exposure time.