### PR TITLE
Make __version__ in line with the pip version

### DIFF
--- a/batman/__init__.py
+++ b/batman/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['transitmodel', 'tests', 'plots']
 
 
-__version__ = "2.2.0"
+__version__ = "2.4.4"
 
 from .transitmodel import *
 from .tests import *


### PR DESCRIPTION
I think you forgot to update the version info. pip says it's on version 2.4.4, but `batman.__version__` still says 2.2.0.