### PR TITLE
setup.py: Fix pip install error in Python 3.9 due to license string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(	name='batman-package',
 	author_email = 'laura.kreidberg@gmail.com',
 	url = 'https://github.com/lkreidberg/batman',
 	packages =['batman'],
-	license = ['GNU GPLv3'],
+	license = 'GNU GPLv3',
 	description ='Fast transit light curve modeling',
 	classifiers = [
 		'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
The `license` parameter in `setup.py` should have been a string rather than a list containing a string. In setuptools>=56.0, this causes `pip install` to fail. Changing it to a string fixes the installation error.

See the [Python 3](https://docs.python.org/3/distutils/setupscript.html#additional-meta-data) and [Python 3](https://docs.python.org/2.7/distutils/setupscript.html#additional-meta-data) documentation of the `license` metadata. As far as I can tell, that the list worked before was due to an implementation detail that's no longer true in the latest version of `setuptools`.