### PR TITLE
Updating to Numpy>=2.0

### DIFF
--- a/c_src/_custom_ld.c
+++ b/c_src/_custom_ld.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 #include <Python.h>
 #include "numpy/arrayobject.h"
 #include "common.h"

--- a/c_src/_eclipse.c
+++ b/c_src/_eclipse.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 #include <Python.h>
 #include "numpy/arrayobject.h"
 

--- a/c_src/_exponential_ld.c
+++ b/c_src/_exponential_ld.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 #include <Python.h>
 #include "numpy/arrayobject.h"
 #include "common.h"

--- a/c_src/_logarithmic_ld.c
+++ b/c_src/_logarithmic_ld.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 #include <Python.h>
 #include "numpy/arrayobject.h"
 #include "common.h"

--- a/c_src/_nonlinear_ld.c
+++ b/c_src/_nonlinear_ld.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 
 #include <Python.h>
 #include "numpy/arrayobject.h"

--- a/c_src/_power2_ld.c
+++ b/c_src/_power2_ld.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 #include <Python.h>
 #include "numpy/arrayobject.h"
 #include "common.h"

--- a/c_src/_quadratic_ld.c
+++ b/c_src/_quadratic_ld.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 #include <Python.h>
 #include "numpy/arrayobject.h"
 

--- a/c_src/_rsky.c
+++ b/c_src/_rsky.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 #include <Python.h>
 #include "numpy/arrayobject.h"
 

--- a/c_src/_uniform_ld.c
+++ b/c_src/_uniform_ld.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 #include <Python.h>
 #include "numpy/arrayobject.h"
 


### PR DESCRIPTION
Hey @lkreidberg 👋 I work with the ExoCTK team at Space Telescope and noticed that when trying to upgrade our package to Numpy 2.0, we get a failure from Batman. We have avoided this issue by pinning our numpy version to `numpy<2.0` and since Batman doesn't have any numpy requirements, it works.

I spent some time looking at the error (assuming numpy>=2.0 and Batman=2.5.2 installed from pip):

```
>>> from exoctk.limb_darkening.spam import TransitModel

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

..... trace back with a bunch of c + python stuff ......

      1 # The batman package: fast computation of exoplanet transit light curves
      2 # Copyright (C) 2015 Laura Kreidberg
      3 #
      (...)
     14 # You should have received a copy of the GNU General Public License
     15 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
     17 import numpy as np
---> 18 from . import _nonlinear_ld
     19 from . import _quadratic_ld
     20 from . import _uniform_ld

ImportError: numpy.core.multiarray failed to import
```

I went ahead and opened up `_nonlinear_ld.c`  in `batman/c_src` and  noticed at the top of the file

`#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION`

and a quick google returned: https://numpy.org/doc/stable/reference/c-api/deprecations.html#c-api-deprecations

I went ahead and tried to change the version:

`#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION`

then installed the the package from source (`pip install .`)

Tried this again and got:

```
>>> import numpy as np
>>> np.__version__
        2.0.0
>>> from exoctk.limb_darkening.spam import TransitModel
```

to see if it was backwards compatible

```
$ pip install numpy==1.26.4
$ python
>>> import numpy as np
>>> np.__version___
        1.26.4
>>>  from exoctk.limb_darkening.spam import TransitModel
```

I will fully admit, I am not very familiar with cython or compiling C/C++ with python libraries so there might be some more in depth testing on the python bits but this seems to solve the imports.