### PR TITLE
Updates to work with Python 3.13

### DIFF
--- a/batman/openmp.py
+++ b/batman/openmp.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from distutils.ccompiler import new_compiler
+from setuptools._distutils.ccompiler import new_compiler
 import os
 import sys
 import tempfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 matplotlib
 pytest
+setuptools


### PR DESCRIPTION
From Python 3.12 onwards distutils has been removed. [PEP632](https://peps.python.org/pep-0632/#migration-advice)

At batman/openmp.py, line 2, changed from distutils to setuptools._distutils.
Updated the requirements.txt accordingly.