### PR TITLE
Removing t_secondary to fix bugs and remove confusion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,10 @@
 .. :changelog:
+
+3.0.0 (2026-03-06)
+~~~~~~~~~~~~~~~~~~
+- Removed t_secondary, because the presence of both t0 and t_secondary caused subtle but serious bugs (see GitHub Issues page).
+- Changed the signature of get_t_conjunction to take t_secondary (which is no longer in TransitParams).  Also renamed the method to get_t_transit to emphasize that it is not the same method.
+   
 2.5.3 (2025-05-05)
 ~~~~~~~~~~~~~~~~~~
 - update CI to latest stable python versions

--- a/batman/__init__.py
+++ b/batman/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ["transitmodel", "tests", "plots"]
 
 
-__version__ = "2.5.1"
+__version__ = "3.0.0"
 
 from .transitmodel import *
 from .tests import *

--- a/batman/transitmodel.py
+++ b/batman/transitmodel.py
@@ -150,7 +150,6 @@ class TransitModel(object):
         self.u = params.u
         self.limb_dark = params.limb_dark
         self.fp = params.fp
-        self.t_secondary = params.t_secondary
         self.max_err = max_err
         self.supersample_factor = supersample_factor
         self.exp_time = exp_time
@@ -172,7 +171,6 @@ class TransitModel(object):
             self.transittype = 1
         else:
             self.transittype = 2
-            params.t0 = self.get_t_conjunction(params)
 
         if fac != None:
             self.fac = fac
@@ -463,10 +461,7 @@ class TransitModel(object):
             or params.inc != self.inc
             or params.ecc != self.ecc
             or params.w != self.w
-            or params.t_secondary != self.t_secondary
         ):
-            if self.transittype == 2 and params.t_secondary != self.t_secondary:
-                params.t0 = self.get_t_conjunction(params)
             self.ds = _rsky._rsky(
                 self.t_supersample,
                 params.t0,
@@ -492,7 +487,6 @@ class TransitModel(object):
         self.u = params.u
         self.limb_dark = params.limb_dark
         self.fp = params.fp
-        self.t_secondary = params.t_secondary
 
         # handles the case of inverse transits (rp < 0)
         self.inverse = False
@@ -618,13 +612,13 @@ class TransitModel(object):
         phase2 = self._get_phase(params, "secondary")
         return params.t0 + params.per * (phase2 - phase)
 
-    def get_t_conjunction(self, params):
+    def get_t_primary(self, params, t_secondary):
         """
-        Return the time of primary transit center (calculated using `params.t_secondary`).
+        Return the time of primary transit center from t_secondary.
         """
         phase = self._get_phase(params, "primary")
         phase2 = self._get_phase(params, "secondary")
-        return params.t_secondary + params.per * (phase - phase2)
+        return t_secondary + params.per * (phase - phase2)
 
     def get_true_anomaly(self):
         """
@@ -650,9 +644,6 @@ class TransitParams(object):
 
     :param t0: Time of inferior conjunction.
     :type t0: float, optional
-
-    :param t_secondary: Time of secondary eclipse center.
-    :type t_secondary: float, optional
 
     :param per: Orbital period.
     :type per: float
@@ -683,7 +674,7 @@ class TransitParams(object):
 
     .. note::
             - Units for the orbital period and ephemeris can be anything as long as they are consistent (e.g. both in days).
-            - The orbital path is calculated based on `t0` for primary transits and `t_secondary` for secondary eclipses.
+            - The orbital path is calculated based on `t0` for both primary and secondary transits
 
     :Example:
 
@@ -711,4 +702,4 @@ class TransitParams(object):
         self.u = None
         self.limb_dark = None
         self.fp = None
-        self.t_secondary = None
+

--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -79,10 +79,11 @@ m.calc_err(plot = True)
 #m = batman.TransitModel(params, t, nthreads = 4)"""
 
 params.fp = 0.001
-params.t_secondary = 0.5
 t = np.linspace(0.48, 0.52, 1000)
 m = batman.TransitModel(params, t, transittype="secondary")	       
 flux = m.light_curve(params)
+
+#Secondary eclipse time is automatically calculated.  To see what it is, call m.get_t_secondary(params)
 
 plt.plot(t, flux)
 plt.ylim((0.9995, 1.0015))

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -179,13 +179,11 @@ The parallelization is done at the C level with OpenMP.  If your default C compi
 
 Modeling eclipses
 -----------------
-``batman`` can also model eclipses (secondary transits). To do this, specify the planet-to-star flux ratio and the central eclipse time:
+``batman`` can also model eclipses (secondary transits). To do this, specify the planet-to-star flux ratio:
 
 ::
 	
 	params.fp = 0.001
-	params.t_secondary = 0.5
-         
 
 and initialize a model with the ``transittype`` parameter set to ``"secondary"``:
 
@@ -201,7 +199,7 @@ and initialize a model with the ``transittype`` parameter set to ``"secondary"``
 The eclipse light curve is normalized such that the flux of the star is unity. The eclipse depth is :math:`f_p`. 
 The model assumes that the eclipse center occurs when the true anomaly equals :math:`3\pi/2 - \omega`. 
 
-For convenience, `batman` includes utilities to calculate the time of secondary eclipse from the time of inferior conjunction, and vice versa. See the ``get_t_secondary`` and ``get_t_conjunction`` methods in the API.
+For convenience, `batman` includes utilities to calculate the time of secondary eclipse from the time of inferior conjunction (transit), and vice versa. See the ``get_t_secondary`` and ``get_t_primary`` methods in the API.
 
 .. warning:: Note that the secondary eclipse calculation does NOT account for the light travel time in the system (which is of order minutes). Future versions of ``batman`` may include this feature, but for now you're on your own!
 


### PR DESCRIPTION
The current way that batman deals with t_secondary when computing eclipses is buggy and confusing.  Users can very easily obtain subtly wrong results and not realize it:

1. If the user specifies both t0 and t_secondary, batman overwrites t0 with the version is calculates from t_secondary, ecc, and w.  However, it doesn't warn the user that this is occurring.
2. Similarly to point 1, it is very easy for the user to create a TransitParams object where t_secondary is inconsistent with t0, ecc, and w without realizing it.
3. Often, the transit time is known precisely and one wants to constrain ecc and w based on an eclipse observation.  There is currently no easy way to do this.  One can fit for t_secondary, ecc, and w, but there is no way to guarantee that the transit time won't change.  One can fit for t0, ecc, and w, but the user easily falls into the aforementioned trap of not realizing that batman overwrites the user-provided t0.
4. In the light_curve method, batman recalculates t0 whenever t_secondary is updated.  However, it does not recalculate t0 when ecc and w are calculated, even though t0 does change.

To address these issues, I propose removing t_secondary altogether, as I do in this pull request.  The user can easily calculate it from the helper method get_t_secondary if necessary.  Since this is a breaking change, if you think it's a good idea, a new major version number is probably necessary.  I tried hard to think of a way to fix these problems without introducing a breaking change and without being extremely confusing, but couldn't come up with any.